### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,15 @@
 name: uQuery Release (binaries, docker)
 
-# Triggered on version tags or manually (manual runs build & test but skip publishing).
+# Triggered on version tags or manually.
+# Manual dispatch accepts an optional tag so a failed release can be retried
+# against an existing tag without creating a new one.
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to re-release (e.g. v0.6.0). Leave empty for a dry run.'
+        required: false
+        default: ''
   push:
     tags:
       - "v*.*.*"
@@ -94,7 +101,7 @@ jobs:
   # Each platform is tested on a native runner (no QEMU emulation).
   # Both must pass before the image is published.
   smoke-test:
-    name: Smoke test / ${{ matrix.arch }}
+    name: Docker - smoke test / ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     needs: build-linux
     strategy:
@@ -140,7 +147,7 @@ jobs:
   # ── Docker image ────────────────────────────────────────────────────────────
   # Smoke tests passed on both platforms — build the final multi-platform image and push.
   docker:
-    name: Docker
+    name: Docker - Final build
     runs-on: ubuntu-latest
     needs: smoke-test
 
@@ -199,13 +206,15 @@ jobs:
           cache-from: type=gha
 
   # ── GitHub Release ──────────────────────────────────────────────────────────
-  # Runs only on tags, after smoke tests pass (via docker) and all binaries are ready.
-  # Packages raw binaries into per-target tarballs before attaching to the release.
+  # Runs on tags or when a tag is supplied via workflow_dispatch.
+  # The release is created as a DRAFT so it can be reviewed before publishing.
+  # To retry a failed release without a new tag: re-trigger via workflow_dispatch
+  # and set the tag input (e.g. v0.6.0).
   github-release:
     name: GitHub Release
     runs-on: ubuntu-latest
     needs: [docker, build-macos]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.tag != ''
 
     steps:
       - name: Download all binaries
@@ -224,7 +233,9 @@ jobs:
           tar -C artifacts/binary-macos-amd64  -czf release/uquery-x86_64-apple-darwin.tar.gz       uquery
           tar -C artifacts/binary-macos-arm64  -czf release/uquery-aarch64-apple-darwin.tar.gz      uquery
 
-      - name: Publish GitHub release
+      - name: Create draft GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          draft: true
           files: release/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,26 @@ on:
 
 jobs:
   # ── Linux binaries ──────────────────────────────────────────────────────────
-  # Built with cross-rs so all three targets compile on a single ubuntu runner.
+  # Each target runs on a native runner — no cross-compilation, no Docker toolchain.
+  # i686 builds on the x86_64 runner using gcc-multilib (32-bit support on 64-bit host).
+  # aarch64 uses GitHub's native arm64 runner (ubuntu-24.04-arm).
   build-linux:
     name: Linux / ${{ matrix.arch }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: amd64
+            runner: ubuntu-latest
           - target: i686-unknown-linux-gnu
             arch: i686
+            runner: ubuntu-latest
+            multilib: true
           - target: aarch64-unknown-linux-gnu
             arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
@@ -35,10 +41,13 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - uses: taiki-e/install-action@cross
+      # Required to compile 32-bit binaries on the 64-bit x86_64 runner.
+      - name: Install multilib (i686 only)
+        if: matrix.multilib
+        run: sudo apt-get install -y gcc-multilib g++-multilib
 
       - name: Build
-        run: cross build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       # Raw binary — smoke-test and docker jobs use amd64/arm64, release job packages all three.
       - uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ENV DUCKDB_VERSION="1.5.1"
 LABEL org.opencontainers.image.authors="florian@flob.fr"
 LABEL org.opencontainers.image.source="https://github.com/fb64/uquery-rs"

--- a/tests/docker_smoke_test.sh
+++ b/tests/docker_smoke_test.sh
@@ -30,7 +30,7 @@ echo -e "${BOLD}Image:${NC} $IMAGE"
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 wait_ready() {
-  local name="$1"
+  local name="$1" target="$2"
   echo -n "Waiting for $name..."
   for i in $(seq 1 30); do
     if curl -sf "$BASE_URL/health" >/dev/null 2>&1; then echo " ready."; return; fi
@@ -38,7 +38,7 @@ wait_ready() {
   done
   echo ""
   echo "Container did not become healthy in 30s. Logs:"
-  docker logs "$CONTAINER" 2>&1 || true
+  docker logs "$target" 2>&1 || true
   exit 1
 }
 
@@ -99,7 +99,7 @@ docker run -d --name "$CONTAINER" \
   -v "$TESTS_DIR:/tmp/tests:ro" \
   "$IMAGE" >/dev/null
 
-wait_ready "container"
+wait_ready "container" "$CONTAINER"
 
 echo ""
 echo -e "${BOLD}Health${NC}"
@@ -142,7 +142,7 @@ docker run -d --name "${CONTAINER}-db" \
   -v "$TESTS_DIR:/tmp/tests:ro" \
   "$IMAGE" -d /tmp/tests/test.db >/dev/null
 
-wait_ready "container with DB"
+wait_ready "container with DB" "${CONTAINER}-db"
 post_body "attached DB: language table has 10 rows" '"count_star()":10' \
   -H "Accept: application/json" -d "SELECT count(*) FROM language"
 

--- a/tests/docker_smoke_test.sh
+++ b/tests/docker_smoke_test.sh
@@ -37,7 +37,8 @@ wait_ready() {
     sleep 1
   done
   echo ""
-  echo "Container did not become healthy in 30s."
+  echo "Container did not become healthy in 30s. Logs:"
+  docker logs "$CONTAINER" 2>&1 || true
   exit 1
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Allow manual release tagging via workflow input and create draft releases from that tag
  * Optimized Linux build workflow to use native per-architecture runners for improved build efficiency
  * Updated Docker base image to the latest Debian distribution
* **Tests**
  * Improved Docker smoke test to print container logs on timeout for easier debugging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->